### PR TITLE
Corrected small issue for no-argument function applications

### DIFF
--- a/src/main/scala/smtlib/printer/PrettyPrinter.scala
+++ b/src/main/scala/smtlib/printer/PrettyPrinter.scala
@@ -205,9 +205,13 @@ object PrettyPrinter {
       printTerm(t, writer)
       writer.write(")")
     case FunctionApplication(fun, ts) =>
-      writer.write("(")
-      printQualifiedId(fun, writer)
-      printNary(writer, ts, printTerm _, " ", " ", ")")
+      if (ts.nonEmpty) {
+        writer.write("(")
+        printQualifiedId(fun, writer)
+        printNary(writer, ts, printTerm _, " ", " ", ")")
+      } else {
+        printQualifiedId(fun, writer)
+      }
     case AnnotatedTerm(term, attr, attrs) => {
       writer.write("(! ")
       printTerm(term, writer)


### PR DESCRIPTION
I didn't look around much in other Leon tests, but I have one example where a no-argument function invocation gets pretty-printed out to (functionName ) and this doesn't seem to parse in CVC4, so I just implemented a quick fix that checks whether the argument list is empty.
