### PR TITLE
Added experimental theory of sets and common operations.

### DIFF
--- a/src/main/scala/smtlib/theories/Common.scala
+++ b/src/main/scala/smtlib/theories/Common.scala
@@ -1,0 +1,48 @@
+package smtlib
+package theories
+
+import parser.Terms._
+
+private[theories] trait Operation1 {
+  def name: String
+
+  def apply(i : Term): Term =
+    FunctionApplication(QualifiedIdentifier(Identifier(SSymbol(name))),
+                          Seq(i))
+
+  def unapply(t : Term): Option[Term] = t match {
+    case FunctionApplication(
+          QualifiedIdentifier(Identifier(SSymbol(n), Seq()), None),
+          Seq(i)) if n == name => Some(i)
+    case _ => None
+  }
+}
+
+private[theories] trait Operation2 {
+  def name: String
+
+  def apply(l : Term, r : Term): Term =
+    FunctionApplication(QualifiedIdentifier(Identifier(SSymbol(name))),
+                          Seq(l,r))
+
+  def unapply(t : Term): Option[(Term, Term)] = t match {
+    case FunctionApplication(
+          QualifiedIdentifier(Identifier(SSymbol(n), Seq()), None),
+          Seq(l,r)) if n == name => Some((l,r))
+    case _ => None
+  }
+}
+
+private[theories] trait OperationN {
+  def name: String
+
+  def apply(is: Seq[Term]): Term =
+    FunctionApplication(QualifiedIdentifier(Identifier(SSymbol(name))), is)
+
+  def unapply(t : Term): Option[Seq[Term]] = t match {
+    case FunctionApplication(
+          QualifiedIdentifier(Identifier(SSymbol(n), Seq()), None),
+          is) if n == name => Some(is)
+    case _ => None
+  }
+}

--- a/src/main/scala/smtlib/theories/experimental/Sets.scala
+++ b/src/main/scala/smtlib/theories/experimental/Sets.scala
@@ -1,0 +1,37 @@
+package smtlib
+package theories
+package experimental
+import parser.Terms._
+
+/* Experimental support for the theory of sets in CVC4
+ * Based on the operations in http://cvc4.cs.nyu.edu/wiki/Sets
+ */
+object Sets {
+  object SetSort {
+    def apply(el : Sort): Sort = Sort(Identifier(SSymbol("Set")), Seq(el))
+
+    def unapply(sort : Sort): Option[Sort] = sort match {
+      case Sort(Identifier(SSymbol("Set"), Seq()), Seq(el)) => Some(el)
+      case _ => None
+    }
+  }
+
+  object Union extends Operation2 { override val name = "union" }
+  object Intersection extends Operation2 { override val name = "intersection" }
+  object Setminus extends Operation2 { override val name = "setminus" }
+  object Member extends Operation2 { override val name = "member" }
+  object Subset extends Operation2 { override val name = "subset" }
+
+  object EmptySet {
+    def apply(s : Sort): Term = QualifiedIdentifier(Identifier(SSymbol("emptyset")), Some(s))
+    def unapply(t : Term): Option[Sort] = t match {
+      case QualifiedIdentifier(Identifier(SSymbol("emptyset"), Seq()), Some(s)) =>
+          Some(s)
+      case _ => None
+    }
+  }
+
+  object Singleton extends Operation1 { override val name = "singleton" }
+
+  object Insert extends OperationN { override val name = "insert" }
+}


### PR DESCRIPTION
I have added operations for the experimental theory of finite sets supported by CVC4,  and additionally I have added traits that encapsulates common patterns of function application found in the standard library, so it is easier to add new operations in the future.

I can also add some tests if needed later, and possibly also refactor some of the operations in the other theories to use the added common operations.

Comments are welcome!