### PR TITLE
Fix for bit vector constant extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ library, so if that fits your needs you should be able to safely use it. It come
 with a relatively extensive test suite to make sure it is working as expected.
 
 
-###Lexing
+### Lexing
 
 The [`lexer`](/src/main/scala/smtlib/lexer) package implements low level
 parsing of [`Tokens`](/src/main/scala/smtlib/lexer/Tokens.scala), The 
@@ -139,7 +139,7 @@ such as `stdin`). The following two exceptions can be thrown by the lexer:
   the EOF.
 
 
-###Parsing
+### Parsing
 
 Usually one does not need to work on a token by token basis, and is only
 interested in fully formated SMT-LIB expressions. The
@@ -168,13 +168,13 @@ the corresponding SMT-LIB command. It is defined
 parameter a `Term`, whose AST is defined
 [here](/src/main/scala/smtlib/parser/Terms.scala).
 
-###Printing
+### Printing
 
 The [`printer`](/src/main/scala/smtlib/printer) helps with printing out SMT-LIB
 complient commands. This means that the output of a printer can be send
 directly to an SMT solver.
 
-###Standard Theories
+### Standard Theories
 
 Finally the [`theories`](/src/main/scala/smtlib/theories) module provides tree
 builders to create theory-specific formulas. Each theory module provides
@@ -190,7 +190,7 @@ and has been made standalone in order for the
 [Leon](https://github.com/epfl-lara/leon) project to rely on it.
 Hopefully, it can be useful to other people as well.
 
-###Testing
+### Testing
 
 In order to attain a decent level of quality, there is a relatively strict policy for testing.
 Testing is separated in two levels of testing: unit tests and integration tests. Unit test
@@ -203,7 +203,7 @@ In SBT, the command `sbt test` will run the unit test suite, while the command
 `sbt it:test` will run the integration test suite. During developement, it
 should be fine to run in mode `~testQuick`.
 
-###Building the Sources
+### Building the Sources
 
 The project is built with [sbt](http://www.scala-sbt.org/). To build the
 library, just type:

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ parallelExecution in Test := true
 lazy val commonSettings = Seq(
   organization := "com.regblanc",
   name := "scala-smtlib",
-  version := "0.2.1",
+  version := "0.2.2",
   scalaVersion := "2.11.8",
   crossScalaVersions := Seq("2.10.4", "2.11.8", "2.12.1")
 )

--- a/src/it/scala/smtlib/it/ProcessInterpreterTests.scala
+++ b/src/it/scala/smtlib/it/ProcessInterpreterTests.scala
@@ -23,8 +23,8 @@ class ProcessInterpreterTests extends FunSuite with TestHelpers {
     //TODO: check against all interpreters
     val z3Interpreter = getZ3Interpreter
 
-    z3Interpreter.eval(parser.Commands.SetLogic(parser.Commands.AUFLIA()))
-    z3Interpreter.eval(parser.Commands.CheckSat())
+    z3Interpreter.eval(trees.Commands.SetLogic(trees.Commands.AUFLIA()))
+    z3Interpreter.eval(trees.Commands.CheckSat())
     z3Interpreter.free()
     z3Interpreter.interrupt()
   }
@@ -33,8 +33,8 @@ class ProcessInterpreterTests extends FunSuite with TestHelpers {
     //TODO: check against all interpreters
     val z3Interpreter = getZ3Interpreter
 
-    z3Interpreter.eval(parser.Commands.SetLogic(parser.Commands.AUFLIA()))
-    z3Interpreter.eval(parser.Commands.CheckSat())
+    z3Interpreter.eval(trees.Commands.SetLogic(trees.Commands.AUFLIA()))
+    z3Interpreter.eval(trees.Commands.CheckSat())
     z3Interpreter.interrupt()
     z3Interpreter.interrupt()
     z3Interpreter.interrupt()

--- a/src/it/scala/smtlib/it/TheoriesBuilderTests.scala
+++ b/src/it/scala/smtlib/it/TheoriesBuilderTests.scala
@@ -10,9 +10,9 @@ import java.io.FileReader
 
 import interpreters._
 
-import parser.Terms._
-import parser.Commands._
-import parser.CommandsResponses._
+import trees.Terms._
+import trees.Commands._
+import trees.CommandsResponses._
 
 
 /** Checks that formula build with theories module are correctly handled by solvers */

--- a/src/main/scala/smtlib/theories/FixedSizeBitVectors.scala
+++ b/src/main/scala/smtlib/theories/FixedSizeBitVectors.scala
@@ -45,12 +45,12 @@ object FixedSizeBitVectors {
       QualifiedIdentifier(Identifier(SSymbol("bv" + x), Seq(SNumeral(n))))
     //TODO: BigInt is not the best data representation for a bitvector, we should probably use a list of boolean kind of representation
     def unapply(term: Term): Option[(BigInt, BigInt)] = term match {
-      case QualifiedIdentifier(Identifier(SSymbol(name), Seq(SNumeral(n))), None) => {
-        if(name.startsWith("bv")) {
-          val value = name.substring(2)
-          scala.util.Try(BigInt(value).toInt).toOption.map(v => (v, n))
-        } else None
-      }
+      case QualifiedIdentifier(
+        Identifier(SSymbol(cst), Seq(SNumeral(size))),
+        None
+      ) if cst startsWith "bv" =>
+        Some(BigInt(cst drop 2) -> size)
+
       case _ => None
     }
   }


### PR DESCRIPTION
as well as test compilation and some minor formatting issues in readme. It also bumps the version to `0.2.2`.

The bitvector patch arises from [this discussion](https://github.com/epfl-lara/inox/pull/26#discussion_r115557951).