### PR TITLE
Allow eval to parse unsat assumption responses

### DIFF
--- a/src/main/scala/smtlib/interpreters/ProcessInterpreter.scala
+++ b/src/main/scala/smtlib/interpreters/ProcessInterpreter.scala
@@ -26,6 +26,7 @@ abstract class ProcessInterpreter(protected val process: Process, tailPrinter: B
     case CheckSat() => parser.parseCheckSatResponse
     case GetAssertions() => parser.parseGetAssertionsResponse
     case GetUnsatCore() => parser.parseGetUnsatCoreResponse
+    case GetUnsatAssumptions() => parser.parseGetUnsatAssumptionsResponse
     case GetProof() => parser.parseGetProofResponse
     case GetValue(_, _) => parser.parseGetValueResponse
     case GetAssignment() => parser.parseGetAssignmentResponse


### PR DESCRIPTION
The latest version of z3 now returns these. See https://github.com/epfl-lara/inox/issues/32.