### PR TITLE
Minor clean ups for better compatibility with recent Scala versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ parallelExecution in Test := true
 lazy val commonSettings = Seq(
   organization := "com.regblanc",
   name := "scala-smtlib",
-  scalaVersion := "2.13.1",
+  scalaVersion := "2.13.4",
   crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.12", "2.13.4")
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ git.useGitDescribe := true
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 scalacOptions ++= {
-  val Seq(_, major, minor) = (scalaVersion in ThisBuild).value.split("\\.").toSeq.map(_.toInt)
+  val Seq(_, major, minor) = scalaVersion.value.split("\\.").toSeq.map(_.toInt)
   if (major <= 10 || (major == 11 && minor < 5)) Seq.empty
   else Seq("-Ypatmat-exhaust-depth", "40")
 }

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val commonSettings = Seq(
   organization := "com.regblanc",
   name := "scala-smtlib",
   scalaVersion := "2.13.1",
-  crossScalaVersions := Seq("2.10.4", "2.11.8", "2.12.1", "2.13.1")
+  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.12", "2.13.4")
 )
 
 lazy val root = (project in file(".")).

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ javaOptions in IntegrationTest ++= Seq("-Xss128M")
 
 fork in IntegrationTest := true
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0-RC3" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.4" % "test"
 
 logBuffered in IntegrationTest := false
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.3
+sbt.version=1.3.13

--- a/src/it/scala/smtlib/it/ProcessInterpreterTests.scala
+++ b/src/it/scala/smtlib/it/ProcessInterpreterTests.scala
@@ -3,7 +3,7 @@ package it
 
 import scala.sys.process._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.File
 import java.io.FileReader
@@ -14,7 +14,7 @@ import printer.RecursivePrinter
 import interpreters._
 
 
-class ProcessInterpreterTests extends FunSuite with TestHelpers {
+class ProcessInterpreterTests extends AnyFunSuite with TestHelpers {
 
   //TODO: properly get all interpreters
   def interpreters: Seq[Interpreter] = Seq(getZ3Interpreter)

--- a/src/it/scala/smtlib/it/SmtLibRunnerTests.scala
+++ b/src/it/scala/smtlib/it/SmtLibRunnerTests.scala
@@ -3,7 +3,7 @@ package it
 
 import scala.sys.process._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.File
 import java.io.FileReader
@@ -21,7 +21,7 @@ import interpreters._
   *
   * TODO: proper way to display warning when not all tests are run because of not found executables.
   */
-class SmtLibRunnerTests extends FunSuite with TestHelpers {
+class SmtLibRunnerTests extends AnyFunSuite with TestHelpers {
 
   filesInResourceDir("regression/smtlib/solving/all", _.endsWith(".smt2")).foreach(file => {
     if(isZ3Available) {

--- a/src/it/scala/smtlib/it/SmtLibRunnerTests.scala
+++ b/src/it/scala/smtlib/it/SmtLibRunnerTests.scala
@@ -72,7 +72,7 @@ class SmtLibRunnerTests extends FunSuite with TestHelpers {
     val lexer = new Lexer(new FileReader(file))
     val parser = new Parser(lexer)
 
-    for(expected <- scala.io.Source.fromFile(want).getLines) {
+    for(expected <- scala.io.Source.fromFile(want).getLines()) {
       val cmd = parser.parseCommand
       assert(cmd !== null)
       val res: String = interpreter.eval(cmd).toString

--- a/src/it/scala/smtlib/it/TestHelpers.scala
+++ b/src/it/scala/smtlib/it/TestHelpers.scala
@@ -26,7 +26,7 @@ trait TestHelpers {
   private val resourceDirHard = "src/it/resources/"
 
   def filesInResourceDir(dir : String, filter : String=>Boolean = all) : Iterable[File] = {    
-    import scala.collection.JavaConversions._
+    import scala.jdk.CollectionConverters._
     val d = this.getClass.getClassLoader.getResource(dir)
 
     val asFile = if(d == null || d.getProtocol != "file") {

--- a/src/it/scala/smtlib/it/TheoriesBuilderTests.scala
+++ b/src/it/scala/smtlib/it/TheoriesBuilderTests.scala
@@ -3,7 +3,7 @@ package it
 
 import scala.sys.process._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.File
 import java.io.FileReader
@@ -16,7 +16,7 @@ import trees.CommandsResponses._
 
 
 /** Checks that formula build with theories module are correctly handled by solvers */
-class TheoriesBuilderTests extends FunSuite with TestHelpers {
+class TheoriesBuilderTests extends AnyFunSuite with TestHelpers {
 
 
   def mkTest(formula: Term, expectedStatus: Status, prefix: String) = {

--- a/src/main/scala/smtlib/extensions/tip/Parser.scala
+++ b/src/main/scala/smtlib/extensions/tip/Parser.scala
@@ -207,7 +207,12 @@ class Parser(lexer: Lexer) extends parser.Parser(lexer) {
       if ((funDec +: funDecs).exists(_.isLeft)) {
         DefineFunsRecPar(funDec +: funDecs, body +: bodies)
       } else {
-        DefineFunsRec((funDec +: funDecs).map(_.right.get), body +: bodies)
+        def getRight(either: Either[FunDecPar, FunDec]) = either match {
+          case Left(_) => throw new NoSuchElementException("getRight() on Left")
+          case Right(a) => a
+        }
+
+        DefineFunsRec((funDec +: funDecs).map(getRight(_)), body +: bodies)
       }
 
     case LT.DeclareDatatypes =>

--- a/src/main/scala/smtlib/parser/ParserCommands.scala
+++ b/src/main/scala/smtlib/parser/ParserCommands.scala
@@ -28,7 +28,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
     }
     case Tokens.CheckSat => CheckSat()
     case Tokens.CheckSatAssuming => {
-      val props = parseMany(parsePropLit _)
+      val props = parseMany(() => parsePropLit)
       CheckSatAssuming(props)
     }
 
@@ -64,8 +64,8 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
       DefineFunRec(funDef)
     }
     case Tokens.DefineFunsRec => {
-      val (funDef, funDefs) = parseOneOrMore(() => parseWithin(Tokens.OParen, Tokens.CParen)(parseFunDec _))
-      val (body, bodies) = parseOneOrMore(parseTerm _)
+      val (funDef, funDefs) = parseOneOrMore(() => parseWithin(Tokens.OParen, Tokens.CParen)(() => parseFunDec))
+      val (body, bodies) = parseOneOrMore(() => parseTerm)
       assert(funDefs.size == bodies.size)
       DefineFunsRec(funDef +: funDefs, body +: bodies)
     }
@@ -151,7 +151,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
       eat(Tokens.OParen)
       eat(Tokens.CParen)
 
-      val datatypes = parseMany(parseDatatypes _)
+      val datatypes = parseMany(() => parseDatatypes)
 
       DeclareDatatypes(datatypes)
     }
@@ -192,7 +192,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
   def parseFunDec: FunDec = {
     val name = parseSymbol
 
-    val sortedVars = parseMany(parseSortedVar _)
+    val sortedVars = parseMany(() => parseSortedVar)
 
     val sort = parseSort
 
@@ -202,7 +202,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
   def parseFunDef: FunDef = {
     val name = parseSymbol
 
-    val sortedVars = parseMany(parseSortedVar _)
+    val sortedVars = parseMany(() => parseSortedVar)
 
     val sort = parseSort
 

--- a/src/main/scala/smtlib/parser/ParserCommands.scala
+++ b/src/main/scala/smtlib/parser/ParserCommands.scala
@@ -22,7 +22,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
     Script(cmds.toList)
   }
 
-  protected def parseCommandWithoutParens: Command = nextToken.kind match {
+  protected def parseCommandWithoutParens: Command = nextToken().kind match {
     case Tokens.Assert => {
       Assert(parseTerm)
     }
@@ -162,7 +162,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
   }
 
   def parseCommand: Command = if(peekToken == null) null else {
-    val head = nextToken
+    val head = nextToken()
     check(head, Tokens.OParen)
     val cmd = parseCommandWithoutParens
     eat(Tokens.CParen)
@@ -241,7 +241,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
 
 
   def parseInfoFlag: InfoFlag = {
-    val t = nextToken
+    val t = nextToken()
     val flag = t match {
       case Tokens.Keyword("all-statistics") => AllStatisticsInfoFlag()
       case Tokens.Keyword("assertion-stack-levels") => AssertionStackLevelsInfoFlag()
@@ -261,52 +261,52 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
     val peekPosition = peekToken.getPos
     val opt = peekToken match {
       case Tokens.Keyword("diagnostic-output-channel") => 
-        nextToken
+        nextToken()
         DiagnosticOutputChannel(parseString.value)
 
       case Tokens.Keyword("global-declarations") => 
-        nextToken
+        nextToken()
         GlobalDeclarations(parseBool)
 
       case Tokens.Keyword("interactive-mode") => 
-        nextToken
+        nextToken()
         InteractiveMode(parseBool)
       case Tokens.Keyword("print-success") =>
-        nextToken
+        nextToken()
         PrintSuccess(parseBool)
 
       case Tokens.Keyword("produce-assertions") => 
-        nextToken
+        nextToken()
         ProduceAssertions(parseBool)
       case Tokens.Keyword("produce-assignments") => 
-        nextToken
+        nextToken()
         ProduceAssignments(parseBool)
       case Tokens.Keyword("produce-models") => 
-        nextToken
+        nextToken()
         ProduceModels(parseBool)
       case Tokens.Keyword("produce-proofs") => 
-        nextToken
+        nextToken()
         ProduceProofs(parseBool)
       case Tokens.Keyword("produce-unsat-assumptions") => 
-        nextToken
+        nextToken()
         ProduceUnsatAssumptions(parseBool)
       case Tokens.Keyword("produce-unsat-cores") => 
-        nextToken
+        nextToken()
         ProduceUnsatCores(parseBool)
 
       case Tokens.Keyword("random-seed") => 
-        nextToken
+        nextToken()
         RandomSeed(parseNumeral.value.toInt)
 
       case Tokens.Keyword("regular-output-channel") => 
-        nextToken
+        nextToken()
         RegularOutputChannel(parseString.value)
 
       case Tokens.Keyword("reproducible-resource-limit") => 
-        nextToken
+        nextToken()
         ReproducibleResourceLimit(parseNumeral.value.toInt)
       case Tokens.Keyword("verbosity") => 
-        nextToken
+        nextToken()
         Verbosity(parseNumeral.value.toInt)
 
       case _ => 
@@ -316,7 +316,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
   }
 
   def parseBool: Boolean = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("true") => true
       case Tokens.SymbolLit("false") => false
       case t => expected(t) //TODO: not sure how to tell we were expecting one of two specific symbols

--- a/src/main/scala/smtlib/parser/ParserCommandsResponses.scala
+++ b/src/main/scala/smtlib/parser/ParserCommandsResponses.scala
@@ -48,7 +48,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            val pairs = parseUntil(Tokens.CParen)(parsePair _)
+            val pairs = parseUntil(Tokens.CParen)(() => parsePair)
             GetAssignmentResponseSuccess(pairs)
           }
         }
@@ -72,7 +72,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            val pairs = parseUntil(Tokens.CParen)(parsePair _)
+            val pairs = parseUntil(Tokens.CParen)(() => parsePair)
             GetValueResponseSuccess(pairs)
           }
         }
@@ -91,7 +91,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
             check(t, Tokens.OParen)
             peekToken match {
               case Tokens.SymbolLit("error") => parseErrorResponse
-              case _ => GetOptionResponseSuccess(SList(parseUntil(Tokens.CParen)(parseSExpr _).toList))
+              case _ => GetOptionResponseSuccess(SList(parseUntil(Tokens.CParen)(() => parseSExpr).toList))
             }
           }
         }
@@ -111,7 +111,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
             check(t, Tokens.OParen)
             peekToken match {
               case Tokens.SymbolLit("error") => parseErrorResponse
-              case _ => GetProofResponseSuccess(SList(parseUntil(Tokens.CParen)(parseSExpr _).toList))
+              case _ => GetProofResponseSuccess(SList(parseUntil(Tokens.CParen)(() => parseSExpr).toList))
             }
           }
         }
@@ -139,7 +139,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
                 case ex: UnknownCommandException => {
                   ex.commandName match { //recover for exceptions case in get-model
                     case Tokens.Forall =>
-                      val vars = parseMany(parseSortedVar _)
+                      val vars = parseMany(() => parseSortedVar)
                       val term = parseTerm
                       eat(Tokens.CParen)
                       exprs.append(Forall(vars.head, vars.tail, term))
@@ -201,7 +201,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            val responses = parseUntil(Tokens.CParen)(parseInfoResponse _)
+            val responses = parseUntil(Tokens.CParen)(() => parseInfoResponse)
             GetInfoResponseSuccess(responses.head, responses.tail)
           }
         }
@@ -241,7 +241,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            val terms = parseUntil(Tokens.CParen)(parseTerm _)
+            val terms = parseUntil(Tokens.CParen)(() => parseTerm)
             GetAssertionsResponseSuccess(terms)
           }
         }
@@ -257,7 +257,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            val syms = parseUntil(Tokens.CParen)(parseSymbol _)
+            val syms = parseUntil(Tokens.CParen)(() => parseSymbol)
             GetUnsatAssumptionsResponseSuccess(syms)
           }
         }
@@ -273,7 +273,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            val syms = parseUntil(Tokens.CParen)(parseSymbol _)
+            val syms = parseUntil(Tokens.CParen)(() => parseSymbol)
             GetUnsatCoreResponseSuccess(syms)
           }
         }

--- a/src/main/scala/smtlib/parser/ParserCommandsResponses.scala
+++ b/src/main/scala/smtlib/parser/ParserCommandsResponses.scala
@@ -15,7 +15,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
    * Parsing error response, assuming "(" has been parsed
    */
   private def parseErrorResponse: Error = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("error") =>
         val msg = parseString.value
         eat(Tokens.CParen)
@@ -24,7 +24,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
     }
   }
 
-  def parseGenResponse: GenResponse = nextToken match {
+  def parseGenResponse: GenResponse = nextToken() match {
     case Tokens.SymbolLit("success") => Success
     case Tokens.SymbolLit("unsupported") => Unsupported
     case t =>
@@ -41,7 +41,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
       (sym, bool)
     }
 
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)
@@ -65,7 +65,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
       (t1, t2)
     }
 
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)
@@ -84,7 +84,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
     tryParseConstant match {
       case Some(cst) => GetOptionResponseSuccess(cst)
       case None => {
-        nextToken match {
+        nextToken() match {
           case Tokens.SymbolLit("unsupported") => Unsupported
           case Tokens.SymbolLit(sym) => GetOptionResponseSuccess(SSymbol(sym))
           case t => {
@@ -103,7 +103,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
     tryParseConstant match {
       case Some(cst) => GetProofResponseSuccess(cst)
       case None => {
-        nextToken match {
+        nextToken() match {
           case Tokens.SymbolLit("unsupported") => Unsupported
           case Tokens.SymbolLit(sym) => GetProofResponseSuccess(SSymbol(sym))
           case Tokens.Keyword(key) => GetProofResponseSuccess(SKeyword(key))
@@ -120,14 +120,14 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseGetModelResponse: GetModelResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            nextToken match {
+            nextToken() match {
               case Tokens.SymbolLit("model") => ()
               case t => expected(t, Tokens.SymbolLitKind) //TODO: expected symbol of value "model"
             }
@@ -160,25 +160,25 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   def parseInfoResponse: InfoResponse = {
     peekToken match {
       case Tokens.Keyword("assertion-stack-levels") =>
-        nextToken
+        nextToken()
         AssertionStackLevelsInfoResponse(parseNumeral.value.toInt)
       case Tokens.Keyword("authors") =>
-        nextToken
+        nextToken()
         AuthorsInfoResponse(parseString.value)
       case Tokens.Keyword("error-behavior") =>
-        nextToken
-        val behaviour = nextToken match {
+        nextToken()
+        val behaviour = nextToken() match {
           case Tokens.SymbolLit("immediate-exit") => ImmediateExitErrorBehavior
           case Tokens.SymbolLit("continued-execution") => ContinuedExecutionErrorBehavior
           case t => expected(t) //TODO: precise error
         }
         ErrorBehaviorInfoResponse(behaviour)
       case Tokens.Keyword("name") =>
-        nextToken
+        nextToken()
         NameInfoResponse(parseString.value)
       case Tokens.Keyword("reason-unknown") =>
-        nextToken
-        val reason = nextToken match {
+        nextToken()
+        val reason = nextToken() match {
           case Tokens.SymbolLit("timeout") => TimeoutReasonUnknown
           case Tokens.SymbolLit("memout") => MemoutReasonUnknown
           case Tokens.SymbolLit("incomplete") => IncompleteReasonUnknown
@@ -186,7 +186,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         }
         ReasonUnknownInfoResponse(reason)
       case Tokens.Keyword("version") =>
-        nextToken
+        nextToken()
         VersionInfoResponse(parseString.value)
       case _ =>
         AttributeInfoResponse(parseAttribute)
@@ -194,7 +194,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseGetInfoResponse: GetInfoResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)
@@ -210,7 +210,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseCheckSatResponse: CheckSatResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("sat") => CheckSatStatus(SatStatus)
       case Tokens.SymbolLit("unsat") => CheckSatStatus(UnsatStatus)
       case Tokens.SymbolLit("unknown") => CheckSatStatus(UnknownStatus)
@@ -223,7 +223,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseEchoResponse: EchoResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.StringLit(value) => EchoResponseSuccess(value)
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
@@ -234,7 +234,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseGetAssertionsResponse: GetAssertionsResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)
@@ -250,7 +250,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseGetUnsatAssumptionsResponse: GetUnsatAssumptionsResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)
@@ -266,7 +266,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseGetUnsatCoreResponse: GetUnsatCoreResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)

--- a/src/main/scala/smtlib/parser/ParserCommon.scala
+++ b/src/main/scala/smtlib/parser/ParserCommon.scala
@@ -70,7 +70,7 @@ trait ParserCommon {
    * Make sure the next token has the expected kind and read it
    */
   protected def eat(expected: TokenKind): Token = {
-    val token = nextToken
+    val token = nextToken()
     check(token, expected)
     token
   }
@@ -78,7 +78,7 @@ trait ParserCommon {
    * Make sure the next token is exactly ``expected`` (usually a symbol lit)
    */
   protected def eat(expected: Token): Token = {
-    val token = nextToken
+    val token = nextToken()
     if(token != expected)
       throw new UnexpectedTokenException(token, Seq(expected.kind))
     token
@@ -181,7 +181,7 @@ trait ParserCommon {
 
 
   def parseKeyword: SKeyword = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.Keyword(k) => {
         val keyword = SKeyword(k)
         keyword.setPos(t)
@@ -253,7 +253,7 @@ trait ParserCommon {
   }
 
   def parseSymbol: SSymbol = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.SymbolLit(s) => {
         val symbol = SSymbol(s)
         symbol.setPos(t)
@@ -270,7 +270,7 @@ trait ParserCommon {
    */
 
   def parseString: SString = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.StringLit(s) => {
         val str = SString(s)
         str.setPos(t)
@@ -280,7 +280,7 @@ trait ParserCommon {
   }
 
   def parseNumeral: SNumeral = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.NumeralLit(n) => {
         val num = SNumeral(n)
         num.setPos(t)
@@ -290,7 +290,7 @@ trait ParserCommon {
   }
 
   def parseDecimal: SDecimal = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.DecimalLit(n) => {
         val dec = SDecimal(n)
         dec.setPos(t)
@@ -300,7 +300,7 @@ trait ParserCommon {
   }
 
   def parseHexadecimal: SHexadecimal = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.HexadecimalLit(h) => {
         val hexa = SHexadecimal(h)
         hexa.setPos(t)
@@ -310,7 +310,7 @@ trait ParserCommon {
   }
 
   def parseBinary: SBinary = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.BinaryLit(b) => {
         val bin = SBinary(b.toList)
         bin.setPos(t)

--- a/src/main/scala/smtlib/parser/ParserCommon.scala
+++ b/src/main/scala/smtlib/parser/ParserCommon.scala
@@ -201,7 +201,7 @@ trait ParserCommon {
       } else {
         val name = parseIdentifier
 
-        val subSorts = parseUntil(Tokens.CParen, eatEnd = false)(parseSort _)
+        val subSorts = parseUntil(Tokens.CParen, eatEnd = false)(() => parseSort)
 
         Sort(name, subSorts.toList).setPos(startPos)
       }
@@ -230,7 +230,7 @@ trait ParserCommon {
     val sym = parseSymbol
 
     val head = parseSExpr
-    val indices = parseUntil(Tokens.CParen, eatEnd = false)(parseSExpr _)
+    val indices = parseUntil(Tokens.CParen, eatEnd = false)(() => parseSExpr)
 
     Identifier(sym, head +: indices)
   }
@@ -245,7 +245,7 @@ trait ParserCommon {
   def parseIdentifier: Identifier = {
     if(getPeekToken.kind == Tokens.OParen) {
       val pos = getPeekToken.getPos
-      parseWithin(Tokens.OParen, Tokens.CParen)(parseUnderscoreIdentifier _).setPos(pos)
+      parseWithin(Tokens.OParen, Tokens.CParen)(() => parseUnderscoreIdentifier).setPos(pos)
     } else {
       val sym = parseSymbol
       Identifier(sym).setPos(sym)
@@ -319,7 +319,7 @@ trait ParserCommon {
     }
   }
 
-  def parseSList: SList = SList(parseMany(parseSExpr _).toList)
+  def parseSList: SList = SList(parseMany(() => parseSExpr).toList)
 
   /**
     *

--- a/src/main/scala/smtlib/parser/ParserTerms.scala
+++ b/src/main/scala/smtlib/parser/ParserTerms.scala
@@ -37,19 +37,19 @@ trait ParserTerms { this: ParserCommon =>
   protected def parseTermWithoutParens(startPos: Position): Term = getPeekToken.kind match {
     case Tokens.Let =>
       eat(Tokens.Let)
-      val (head, bindings) = parseOneOrMore(parseVarBinding _)
+      val (head, bindings) = parseOneOrMore(() => parseVarBinding)
       val term = parseTerm
       Let(head, bindings, term)
 
     case Tokens.Forall =>
       eat(Tokens.Forall)
-      val (head, vars) = parseOneOrMore(parseSortedVar _)
+      val (head, vars) = parseOneOrMore(() => parseSortedVar)
       val term = parseTerm
       Forall(head, vars, term)
 
     case Tokens.Exists =>
       eat(Tokens.Exists)
-      val (head, vars) = parseOneOrMore(parseSortedVar _)
+      val (head, vars) = parseOneOrMore(() => parseSortedVar)
       val term = parseTerm
       Exists(head, vars, term)
 
@@ -57,7 +57,7 @@ trait ParserTerms { this: ParserCommon =>
       eat(Tokens.ExclamationMark)
       val term = parseTerm
       val head = parseAttribute
-      val attrs = parseUntil(Tokens.CParen, eatEnd = false)(parseAttribute _)
+      val attrs = parseUntil(Tokens.CParen, eatEnd = false)(() => parseAttribute)
       AnnotatedTerm(term, head, attrs)
 
     case Tokens.As =>
@@ -69,7 +69,7 @@ trait ParserTerms { this: ParserCommon =>
     case _ => //should be function application
       val id = parseQualifiedIdentifier 
       val head = parseTerm
-      val terms = parseUntil(Tokens.CParen, eatEnd = false)(parseTerm _)
+      val terms = parseUntil(Tokens.CParen, eatEnd = false)(() => parseTerm)
       FunctionApplication(id, head::terms.toList)
   }
 

--- a/src/test/scala/smtlib/common/BinaryTests.scala
+++ b/src/test/scala/smtlib/common/BinaryTests.scala
@@ -1,9 +1,9 @@
 package smtlib
 package common
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class BinaryTests extends FunSuite {
+class BinaryTests extends AnyFunSuite {
 
   test("toIntBits works with one bit") {
     assert(Binary(List(true)).toIntBits === 1)

--- a/src/test/scala/smtlib/common/HexadecimalTests.scala
+++ b/src/test/scala/smtlib/common/HexadecimalTests.scala
@@ -1,9 +1,9 @@
 package smtlib
 package common
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class HexadecimalTests extends FunSuite {
+class HexadecimalTests extends AnyFunSuite {
 
   test("Build hexadecimal with one digit string") {
     val zero = Hexadecimal.fromString("0")

--- a/src/test/scala/smtlib/common/LinkedListTests.scala
+++ b/src/test/scala/smtlib/common/LinkedListTests.scala
@@ -1,8 +1,8 @@
 package smtlib.common
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class LinkedListTests extends FunSuite {
+class LinkedListTests extends AnyFunSuite {
 
 
   test("append one element on empty list pop the same element") {

--- a/src/test/scala/smtlib/lexer/LexerTests.scala
+++ b/src/test/scala/smtlib/lexer/LexerTests.scala
@@ -8,12 +8,12 @@ import Lexer.IllegalTokenException
 
 import java.io.StringReader
 
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.TimeLimits
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.time.SpanSugar._
 
 
-class LexerTests extends FunSuite with TimeLimits {
+class LexerTests extends AnyFunSuite with TimeLimits {
 
 
   override def suiteName = "Lexer Test Suite"

--- a/src/test/scala/smtlib/parser/CommandsParserTests.scala
+++ b/src/test/scala/smtlib/parser/CommandsParserTests.scala
@@ -11,12 +11,12 @@ import trees.TreesOps
 
 import java.io.StringReader
 
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.TimeLimits
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.language.implicitConversions
 
-class CommandsParserTests extends FunSuite with TimeLimits {
+class CommandsParserTests extends AnyFunSuite with TimeLimits {
 
   override def suiteName = "SMT-LIB commands Parser suite"
 

--- a/src/test/scala/smtlib/parser/CommandsResponsesParserTests.scala
+++ b/src/test/scala/smtlib/parser/CommandsResponsesParserTests.scala
@@ -7,11 +7,11 @@ import trees.Commands._
 import trees.CommandsResponses._
 import trees.Terms._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.language.implicitConversions
 
-class CommandsResponsesParserTests extends FunSuite {
+class CommandsResponsesParserTests extends AnyFunSuite {
 
   private implicit def strToSym(str: String): SSymbol = SSymbol(str)
   private implicit def strToId(str: String): Identifier = Identifier(SSymbol(str))

--- a/src/test/scala/smtlib/parser/ParserTests.scala
+++ b/src/test/scala/smtlib/parser/ParserTests.scala
@@ -11,13 +11,13 @@ import trees.TreesOps
 
 import java.io.StringReader
 
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.TimeLimits
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.time.SpanSugar._
 
 import scala.language.implicitConversions
 
-class ParserTests extends FunSuite with TimeLimits {
+class ParserTests extends AnyFunSuite with TimeLimits {
 
   override def suiteName = "SMT-LIB Parser suite"
 

--- a/src/test/scala/smtlib/parser/TermsOpsTests.scala
+++ b/src/test/scala/smtlib/parser/TermsOpsTests.scala
@@ -1,12 +1,12 @@
 package smtlib
 package trees
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import Terms._
 import TermsOps._
 
-class TermsOpsTests extends FunSuite {
+class TermsOpsTests extends AnyFunSuite {
 
   val s1 = Sort(Identifier(SSymbol("S1")))
   val s2 = Sort(Identifier(SSymbol("S2")))

--- a/src/test/scala/smtlib/parser/TreesOpsTests.scala
+++ b/src/test/scala/smtlib/parser/TreesOpsTests.scala
@@ -1,13 +1,13 @@
 package smtlib
 package trees
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import Terms._
 import Commands._
 import TreesOps._
 
-class TreesOpsTests extends FunSuite {
+class TreesOpsTests extends AnyFunSuite {
 
   val s1 = Sort(Identifier(SSymbol("S1")))
   val s2 = Sort(Identifier(SSymbol("S2")))

--- a/src/test/scala/smtlib/printer/PrinterTests.scala
+++ b/src/test/scala/smtlib/printer/PrinterTests.scala
@@ -8,12 +8,12 @@ import parser.Parser
 
 import common._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-import scala.language.implicitConversions
 import scala.annotation.tailrec
+import scala.language.implicitConversions
 
-class PrinterTests extends FunSuite {
+class PrinterTests extends AnyFunSuite {
 
   /*
    * TODO: test the requirement from the standard:

--- a/src/test/scala/smtlib/theories/ArraysExTests.scala
+++ b/src/test/scala/smtlib/theories/ArraysExTests.scala
@@ -5,9 +5,9 @@ import trees.Terms._
 import ArraysEx._
 import Ints.{IntSort, NumeralLit}
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ArraysExTests extends FunSuite {
+class ArraysExTests extends AnyFunSuite {
 
   override def suiteName = "ArraysEx Theory test suite"
 

--- a/src/test/scala/smtlib/theories/CoreTests.scala
+++ b/src/test/scala/smtlib/theories/CoreTests.scala
@@ -4,9 +4,9 @@ package theories
 import trees.Terms._
 import Core._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class CoreTests extends FunSuite {
+class CoreTests extends AnyFunSuite {
 
   override def suiteName = "Core Theory test suite"
 

--- a/src/test/scala/smtlib/theories/FixedSizeBitVectorsTests.scala
+++ b/src/test/scala/smtlib/theories/FixedSizeBitVectorsTests.scala
@@ -4,9 +4,9 @@ package theories
 import FixedSizeBitVectors._
 import parser.Parser
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class FixedSizeBitVectorsTests extends FunSuite {
+class FixedSizeBitVectorsTests extends AnyFunSuite {
 
   override def suiteName = "Bit Vector theory test suite"
 

--- a/src/test/scala/smtlib/theories/IntsTests.scala
+++ b/src/test/scala/smtlib/theories/IntsTests.scala
@@ -3,9 +3,9 @@ package theories
 
 import Ints._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class IntsTests extends FunSuite {
+class IntsTests extends AnyFunSuite {
 
   override def suiteName = "Ints theory test suite"
 

--- a/src/test/scala/smtlib/theories/RealsTests.scala
+++ b/src/test/scala/smtlib/theories/RealsTests.scala
@@ -3,9 +3,9 @@ package theories
 
 import Reals._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class RealsTests extends FunSuite {
+class RealsTests extends AnyFunSuite {
 
   override def suiteName = "Reals theory test suite"
 

--- a/src/test/scala/smtlib/theories/experimental/SetsTests.scala
+++ b/src/test/scala/smtlib/theories/experimental/SetsTests.scala
@@ -7,9 +7,10 @@ import trees.Terms._
 import Sets._
 import Ints.{IntSort, NumeralLit}
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class SetsTests extends FunSuite with Matchers {
+class SetsTests extends AnyFunSuite with Matchers {
 
   override def suiteName = "Set theory test suite"
 

--- a/src/test/scala/smtlib/theories/experimental/StringsTests.scala
+++ b/src/test/scala/smtlib/theories/experimental/StringsTests.scala
@@ -7,9 +7,10 @@ import trees.Terms._
 import Strings._
 import Ints.NumeralLit
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class StringsTests extends FunSuite with Matchers {
+class StringsTests extends AnyFunSuite with Matchers {
 
   override def suiteName = "Strings theory test suite"
 


### PR DESCRIPTION
These changes allow `scala-smtlib` to be compiled with Scala 2.10.7, 2.11.12, 2.12.12, and 2.13.4.
This includes also an update of the classes so that they avoid using deprecated `scalatest` classes.
The warnings about `InteractiveMode` can be selectively silenced, but only with Scala 2.13 and the `@nowarn` annotation, so I left it as is in this branch.
Feel free to cherry pick whatever you like.