### PR TITLE
Do not rely on automatic activation

### DIFF
--- a/src/it/scala/smtlib/it/SmtLibRunnerTests.scala
+++ b/src/it/scala/smtlib/it/SmtLibRunnerTests.scala
@@ -72,7 +72,7 @@ class SmtLibRunnerTests extends FunSuite with TestHelpers {
     val lexer = new Lexer(new FileReader(file))
     val parser = new Parser(lexer)
 
-    for(expected <- scala.io.Source.fromFile(want).getLines) {
+    for(expected <- scala.io.Source.fromFile(want).getLines()) {
       val cmd = parser.parseCommand
       assert(cmd !== null)
       val res: String = interpreter.eval(cmd).toString

--- a/src/main/scala/smtlib/parser/ParserCommands.scala
+++ b/src/main/scala/smtlib/parser/ParserCommands.scala
@@ -22,7 +22,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
     Script(cmds.toList)
   }
 
-  protected def parseCommandWithoutParens: Command = nextToken.kind match {
+  protected def parseCommandWithoutParens: Command = nextToken().kind match {
     case Tokens.Assert => {
       Assert(parseTerm)
     }
@@ -162,7 +162,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
   }
 
   def parseCommand: Command = if(peekToken == null) null else {
-    val head = nextToken
+    val head = nextToken()
     check(head, Tokens.OParen)
     val cmd = parseCommandWithoutParens
     eat(Tokens.CParen)
@@ -241,7 +241,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
 
 
   def parseInfoFlag: InfoFlag = {
-    val t = nextToken
+    val t = nextToken()
     val flag = t match {
       case Tokens.Keyword("all-statistics") => AllStatisticsInfoFlag()
       case Tokens.Keyword("assertion-stack-levels") => AssertionStackLevelsInfoFlag()
@@ -261,52 +261,52 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
     val peekPosition = peekToken.getPos
     val opt = peekToken match {
       case Tokens.Keyword("diagnostic-output-channel") => 
-        nextToken
+        nextToken()
         DiagnosticOutputChannel(parseString.value)
 
       case Tokens.Keyword("global-declarations") => 
-        nextToken
+        nextToken()
         GlobalDeclarations(parseBool)
 
       case Tokens.Keyword("interactive-mode") => 
-        nextToken
+        nextToken()
         InteractiveMode(parseBool)
       case Tokens.Keyword("print-success") =>
-        nextToken
+        nextToken()
         PrintSuccess(parseBool)
 
       case Tokens.Keyword("produce-assertions") => 
-        nextToken
+        nextToken()
         ProduceAssertions(parseBool)
       case Tokens.Keyword("produce-assignments") => 
-        nextToken
+        nextToken()
         ProduceAssignments(parseBool)
       case Tokens.Keyword("produce-models") => 
-        nextToken
+        nextToken()
         ProduceModels(parseBool)
       case Tokens.Keyword("produce-proofs") => 
-        nextToken
+        nextToken()
         ProduceProofs(parseBool)
       case Tokens.Keyword("produce-unsat-assumptions") => 
-        nextToken
+        nextToken()
         ProduceUnsatAssumptions(parseBool)
       case Tokens.Keyword("produce-unsat-cores") => 
-        nextToken
+        nextToken()
         ProduceUnsatCores(parseBool)
 
       case Tokens.Keyword("random-seed") => 
-        nextToken
+        nextToken()
         RandomSeed(parseNumeral.value.toInt)
 
       case Tokens.Keyword("regular-output-channel") => 
-        nextToken
+        nextToken()
         RegularOutputChannel(parseString.value)
 
       case Tokens.Keyword("reproducible-resource-limit") => 
-        nextToken
+        nextToken()
         ReproducibleResourceLimit(parseNumeral.value.toInt)
       case Tokens.Keyword("verbosity") => 
-        nextToken
+        nextToken()
         Verbosity(parseNumeral.value.toInt)
 
       case _ => 
@@ -316,7 +316,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
   }
 
   def parseBool: Boolean = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("true") => true
       case Tokens.SymbolLit("false") => false
       case t => expected(t) //TODO: not sure how to tell we were expecting one of two specific symbols

--- a/src/main/scala/smtlib/parser/ParserCommandsResponses.scala
+++ b/src/main/scala/smtlib/parser/ParserCommandsResponses.scala
@@ -15,7 +15,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
    * Parsing error response, assuming "(" has been parsed
    */
   private def parseErrorResponse: Error = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("error") =>
         val msg = parseString.value
         eat(Tokens.CParen)
@@ -24,7 +24,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
     }
   }
 
-  def parseGenResponse: GenResponse = nextToken match {
+  def parseGenResponse: GenResponse = nextToken() match {
     case Tokens.SymbolLit("success") => Success
     case Tokens.SymbolLit("unsupported") => Unsupported
     case t =>
@@ -41,7 +41,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
       (sym, bool)
     }
 
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)
@@ -65,7 +65,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
       (t1, t2)
     }
 
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)
@@ -84,7 +84,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
     tryParseConstant match {
       case Some(cst) => GetOptionResponseSuccess(cst)
       case None => {
-        nextToken match {
+        nextToken() match {
           case Tokens.SymbolLit("unsupported") => Unsupported
           case Tokens.SymbolLit(sym) => GetOptionResponseSuccess(SSymbol(sym))
           case t => {
@@ -103,7 +103,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
     tryParseConstant match {
       case Some(cst) => GetProofResponseSuccess(cst)
       case None => {
-        nextToken match {
+        nextToken() match {
           case Tokens.SymbolLit("unsupported") => Unsupported
           case Tokens.SymbolLit(sym) => GetProofResponseSuccess(SSymbol(sym))
           case Tokens.Keyword(key) => GetProofResponseSuccess(SKeyword(key))
@@ -120,14 +120,14 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseGetModelResponse: GetModelResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            nextToken match {
+            nextToken() match {
               case Tokens.SymbolLit("model") => ()
               case t => expected(t, Tokens.SymbolLitKind) //TODO: expected symbol of value "model"
             }
@@ -160,25 +160,25 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   def parseInfoResponse: InfoResponse = {
     peekToken match {
       case Tokens.Keyword("assertion-stack-levels") =>
-        nextToken
+        nextToken()
         AssertionStackLevelsInfoResponse(parseNumeral.value.toInt)
       case Tokens.Keyword("authors") =>
-        nextToken
+        nextToken()
         AuthorsInfoResponse(parseString.value)
       case Tokens.Keyword("error-behavior") =>
-        nextToken
-        val behaviour = nextToken match {
+        nextToken()
+        val behaviour = nextToken() match {
           case Tokens.SymbolLit("immediate-exit") => ImmediateExitErrorBehavior
           case Tokens.SymbolLit("continued-execution") => ContinuedExecutionErrorBehavior
           case t => expected(t) //TODO: precise error
         }
         ErrorBehaviorInfoResponse(behaviour)
       case Tokens.Keyword("name") =>
-        nextToken
+        nextToken()
         NameInfoResponse(parseString.value)
       case Tokens.Keyword("reason-unknown") =>
-        nextToken
-        val reason = nextToken match {
+        nextToken()
+        val reason = nextToken() match {
           case Tokens.SymbolLit("timeout") => TimeoutReasonUnknown
           case Tokens.SymbolLit("memout") => MemoutReasonUnknown
           case Tokens.SymbolLit("incomplete") => IncompleteReasonUnknown
@@ -186,7 +186,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         }
         ReasonUnknownInfoResponse(reason)
       case Tokens.Keyword("version") =>
-        nextToken
+        nextToken()
         VersionInfoResponse(parseString.value)
       case _ =>
         AttributeInfoResponse(parseAttribute)
@@ -194,7 +194,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseGetInfoResponse: GetInfoResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)
@@ -210,7 +210,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseCheckSatResponse: CheckSatResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("sat") => CheckSatStatus(SatStatus)
       case Tokens.SymbolLit("unsat") => CheckSatStatus(UnsatStatus)
       case Tokens.SymbolLit("unknown") => CheckSatStatus(UnknownStatus)
@@ -223,7 +223,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseEchoResponse: EchoResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.StringLit(value) => EchoResponseSuccess(value)
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
@@ -234,7 +234,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseGetAssertionsResponse: GetAssertionsResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)
@@ -250,7 +250,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseGetUnsatAssumptionsResponse: GetUnsatAssumptionsResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)
@@ -266,7 +266,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
   }
 
   def parseGetUnsatCoreResponse: GetUnsatCoreResponse = {
-    nextToken match {
+    nextToken() match {
       case Tokens.SymbolLit("unsupported") => Unsupported
       case t => {
         check(t, Tokens.OParen)

--- a/src/main/scala/smtlib/parser/ParserCommon.scala
+++ b/src/main/scala/smtlib/parser/ParserCommon.scala
@@ -70,7 +70,7 @@ trait ParserCommon {
    * Make sure the next token has the expected kind and read it
    */
   protected def eat(expected: TokenKind): Token = {
-    val token = nextToken
+    val token = nextToken()
     check(token, expected)
     token
   }
@@ -78,7 +78,7 @@ trait ParserCommon {
    * Make sure the next token is exactly ``expected`` (usually a symbol lit)
    */
   protected def eat(expected: Token): Token = {
-    val token = nextToken
+    val token = nextToken()
     if(token != expected)
       throw new UnexpectedTokenException(token, Seq(expected.kind))
     token
@@ -181,7 +181,7 @@ trait ParserCommon {
 
 
   def parseKeyword: SKeyword = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.Keyword(k) => {
         val keyword = SKeyword(k)
         keyword.setPos(t)
@@ -253,7 +253,7 @@ trait ParserCommon {
   }
 
   def parseSymbol: SSymbol = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.SymbolLit(s) => {
         val symbol = SSymbol(s)
         symbol.setPos(t)
@@ -270,7 +270,7 @@ trait ParserCommon {
    */
 
   def parseString: SString = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.StringLit(s) => {
         val str = SString(s)
         str.setPos(t)
@@ -280,7 +280,7 @@ trait ParserCommon {
   }
 
   def parseNumeral: SNumeral = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.NumeralLit(n) => {
         val num = SNumeral(n)
         num.setPos(t)
@@ -290,7 +290,7 @@ trait ParserCommon {
   }
 
   def parseDecimal: SDecimal = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.DecimalLit(n) => {
         val dec = SDecimal(n)
         dec.setPos(t)
@@ -300,7 +300,7 @@ trait ParserCommon {
   }
 
   def parseHexadecimal: SHexadecimal = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.HexadecimalLit(h) => {
         val hexa = SHexadecimal(h)
         hexa.setPos(t)
@@ -310,7 +310,7 @@ trait ParserCommon {
   }
 
   def parseBinary: SBinary = {
-    nextToken match {
+    nextToken() match {
       case t@Tokens.BinaryLit(b) => {
         val bin = SBinary(b.toList)
         bin.setPos(t)


### PR DESCRIPTION
This is a part of cleanups I did to get the library work with Scala 2.13 in the Renaissance benchmark suite.