### PR TITLE
Use scala.jdk.CollectionJonverters instead of JavaConversions

### DIFF
--- a/src/it/scala/smtlib/it/TestHelpers.scala
+++ b/src/it/scala/smtlib/it/TestHelpers.scala
@@ -26,7 +26,7 @@ trait TestHelpers {
   private val resourceDirHard = "src/it/resources/"
 
   def filesInResourceDir(dir : String, filter : String=>Boolean = all) : Iterable[File] = {    
-    import scala.collection.JavaConversions._
+    import scala.jdk.CollectionConverters._
     val d = this.getClass.getClassLoader.getResource(dir)
 
     val asFile = if(d == null || d.getProtocol != "file") {


### PR DESCRIPTION
This is a part of cleanups I did to get the library work with Scala 2.13 in the Renaissance benchmark suite.