### PR TITLE
Access the Right of Either in a compatible fashion

### DIFF
--- a/src/main/scala/smtlib/extensions/tip/Parser.scala
+++ b/src/main/scala/smtlib/extensions/tip/Parser.scala
@@ -207,7 +207,12 @@ class Parser(lexer: Lexer) extends parser.Parser(lexer) {
       if ((funDec +: funDecs).exists(_.isLeft)) {
         DefineFunsRecPar(funDec +: funDecs, body +: bodies)
       } else {
-        DefineFunsRec((funDec +: funDecs).map(_.right.get), body +: bodies)
+        def getRight(either: Either[FunDecPar, FunDec]) = either match {
+          case Left(_) => throw new NoSuchElementException("getRight() on Left")
+          case Right(a) => a
+        }
+
+        DefineFunsRec((funDec +: funDecs).map(getRight(_)), body +: bodies)
       }
 
     case LT.DeclareDatatypes =>


### PR DESCRIPTION
Either is right-biased since Scala 2.13.0 and methods should be used directly on Either. Converting Either to Option and then getting the value preserves the original semantics (throw if Either was Left), but does not work in Scala 2.10. Pattern matching does.

This is a part of cleanups I did to get the library work with Scala 2.13 in the Renaissance benchmark suite.