### PR TITLE
Add (exception-throwing) defaults to non-exhaustive pattern matches

### DIFF
--- a/src/main/scala/smtlib/drivers/SemanticsDriver.scala
+++ b/src/main/scala/smtlib/drivers/SemanticsDriver.scala
@@ -132,6 +132,8 @@ class SemanticsDriver(
 
     case AttributeOption(attribute) =>
       regularOutputChannel(Unsupported)
+
+    case _ => ???
   }
 
   protected def processGetInfo(infoFlag: InfoFlag): Unit = infoFlag match {

--- a/src/main/scala/smtlib/printer/PrintingContext.scala
+++ b/src/main/scala/smtlib/printer/PrintingContext.scala
@@ -484,6 +484,8 @@ class PrintingContext(writer: Writer) {
 
     case AttributeOption(attribute) =>
       print(attribute)
+
+    case _ => ???
   }
 
   protected def printInfoResponse(infoResponse: InfoResponse): Unit = infoResponse match {

--- a/src/test/scala/smtlib/parser/ParserTests.scala
+++ b/src/test/scala/smtlib/parser/ParserTests.scala
@@ -428,12 +428,14 @@ class ParserTests extends FunSuite with TimeLimits {
       case ExtendedIdentifier(a, b) => 
         assert(a === abc)
         assert(b === ext)
+      case _ => ???
     }
     extId match {
       case SimpleIdentifier(sym) => assert(false)
       case ExtendedIdentifier(a, b) => 
         assert(a === abc)
         assert(b === ext)
+      case _ => ???
     }
 
   }

--- a/src/test/scala/smtlib/theories/experimental/SetsTests.scala
+++ b/src/test/scala/smtlib/theories/experimental/SetsTests.scala
@@ -39,6 +39,7 @@ class SetsTests extends FunSuite with Matchers {
       case EmptySet(Reals.RealSort()) => assert(false)
       case NumeralLit(_) => assert(false)
       case EmptySet(IntSort()) => assert(true)
+      case _ => ???
     }
   }
 


### PR DESCRIPTION
This is to silence the warnings while making sure that the code does not run through some unexpected paths.

This is a part of cleanups I did to get the library work with Scala 2.13 in the Renaissance benchmark suite.