### PR TITLE
Use function literals to convert methods to functions

### DIFF
--- a/src/main/scala/smtlib/parser/ParserCommands.scala
+++ b/src/main/scala/smtlib/parser/ParserCommands.scala
@@ -28,7 +28,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
     }
     case Tokens.CheckSat => CheckSat()
     case Tokens.CheckSatAssuming => {
-      val props = parseMany(parsePropLit _)
+      val props = parseMany(() => parsePropLit)
       CheckSatAssuming(props)
     }
 
@@ -64,8 +64,8 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
       DefineFunRec(funDef)
     }
     case Tokens.DefineFunsRec => {
-      val (funDef, funDefs) = parseOneOrMore(() => parseWithin(Tokens.OParen, Tokens.CParen)(parseFunDec _))
-      val (body, bodies) = parseOneOrMore(parseTerm _)
+      val (funDef, funDefs) = parseOneOrMore(() => parseWithin(Tokens.OParen, Tokens.CParen)(() => parseFunDec))
+      val (body, bodies) = parseOneOrMore(() => parseTerm)
       assert(funDefs.size == bodies.size)
       DefineFunsRec(funDef +: funDefs, body +: bodies)
     }
@@ -151,7 +151,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
       eat(Tokens.OParen)
       eat(Tokens.CParen)
 
-      val datatypes = parseMany(parseDatatypes _)
+      val datatypes = parseMany(() => parseDatatypes)
 
       DeclareDatatypes(datatypes)
     }
@@ -192,7 +192,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
   def parseFunDec: FunDec = {
     val name = parseSymbol
 
-    val sortedVars = parseMany(parseSortedVar _)
+    val sortedVars = parseMany(() => parseSortedVar)
 
     val sort = parseSort
 
@@ -202,7 +202,7 @@ trait ParserCommands { this: ParserCommon with ParserTerms =>
   def parseFunDef: FunDef = {
     val name = parseSymbol
 
-    val sortedVars = parseMany(parseSortedVar _)
+    val sortedVars = parseMany(() => parseSortedVar)
 
     val sort = parseSort
 

--- a/src/main/scala/smtlib/parser/ParserCommandsResponses.scala
+++ b/src/main/scala/smtlib/parser/ParserCommandsResponses.scala
@@ -48,7 +48,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            val pairs = parseUntil(Tokens.CParen)(parsePair _)
+            val pairs = parseUntil(Tokens.CParen)(() => parsePair)
             GetAssignmentResponseSuccess(pairs)
           }
         }
@@ -72,7 +72,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            val pairs = parseUntil(Tokens.CParen)(parsePair _)
+            val pairs = parseUntil(Tokens.CParen)(() => parsePair)
             GetValueResponseSuccess(pairs)
           }
         }
@@ -91,7 +91,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
             check(t, Tokens.OParen)
             peekToken match {
               case Tokens.SymbolLit("error") => parseErrorResponse
-              case _ => GetOptionResponseSuccess(SList(parseUntil(Tokens.CParen)(parseSExpr _).toList))
+              case _ => GetOptionResponseSuccess(SList(parseUntil(Tokens.CParen)(() => parseSExpr).toList))
             }
           }
         }
@@ -111,7 +111,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
             check(t, Tokens.OParen)
             peekToken match {
               case Tokens.SymbolLit("error") => parseErrorResponse
-              case _ => GetProofResponseSuccess(SList(parseUntil(Tokens.CParen)(parseSExpr _).toList))
+              case _ => GetProofResponseSuccess(SList(parseUntil(Tokens.CParen)(() => parseSExpr).toList))
             }
           }
         }
@@ -139,7 +139,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
                 case ex: UnknownCommandException => {
                   ex.commandName match { //recover for exceptions case in get-model
                     case Tokens.Forall =>
-                      val vars = parseMany(parseSortedVar _)
+                      val vars = parseMany(() => parseSortedVar)
                       val term = parseTerm
                       eat(Tokens.CParen)
                       exprs.append(Forall(vars.head, vars.tail, term))
@@ -201,7 +201,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            val responses = parseUntil(Tokens.CParen)(parseInfoResponse _)
+            val responses = parseUntil(Tokens.CParen)(() => parseInfoResponse)
             GetInfoResponseSuccess(responses.head, responses.tail)
           }
         }
@@ -241,7 +241,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            val terms = parseUntil(Tokens.CParen)(parseTerm _)
+            val terms = parseUntil(Tokens.CParen)(() => parseTerm)
             GetAssertionsResponseSuccess(terms)
           }
         }
@@ -257,7 +257,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            val syms = parseUntil(Tokens.CParen)(parseSymbol _)
+            val syms = parseUntil(Tokens.CParen)(() => parseSymbol)
             GetUnsatAssumptionsResponseSuccess(syms)
           }
         }
@@ -273,7 +273,7 @@ trait ParserCommandsResponses { this: ParserCommon with ParserTerms with ParserC
         peekToken match {
           case Tokens.SymbolLit("error") => parseErrorResponse
           case t => {
-            val syms = parseUntil(Tokens.CParen)(parseSymbol _)
+            val syms = parseUntil(Tokens.CParen)(() => parseSymbol)
             GetUnsatCoreResponseSuccess(syms)
           }
         }

--- a/src/main/scala/smtlib/parser/ParserCommon.scala
+++ b/src/main/scala/smtlib/parser/ParserCommon.scala
@@ -201,7 +201,7 @@ trait ParserCommon {
       } else {
         val name = parseIdentifier
 
-        val subSorts = parseUntil(Tokens.CParen, eatEnd = false)(parseSort _)
+        val subSorts = parseUntil(Tokens.CParen, eatEnd = false)(() => parseSort)
 
         Sort(name, subSorts.toList).setPos(startPos)
       }
@@ -230,7 +230,7 @@ trait ParserCommon {
     val sym = parseSymbol
 
     val head = parseSExpr
-    val indices = parseUntil(Tokens.CParen, eatEnd = false)(parseSExpr _)
+    val indices = parseUntil(Tokens.CParen, eatEnd = false)(() => parseSExpr)
 
     Identifier(sym, head +: indices)
   }
@@ -245,7 +245,7 @@ trait ParserCommon {
   def parseIdentifier: Identifier = {
     if(getPeekToken.kind == Tokens.OParen) {
       val pos = getPeekToken.getPos
-      parseWithin(Tokens.OParen, Tokens.CParen)(parseUnderscoreIdentifier _).setPos(pos)
+      parseWithin(Tokens.OParen, Tokens.CParen)(() => parseUnderscoreIdentifier).setPos(pos)
     } else {
       val sym = parseSymbol
       Identifier(sym).setPos(sym)
@@ -319,7 +319,7 @@ trait ParserCommon {
     }
   }
 
-  def parseSList: SList = SList(parseMany(parseSExpr _).toList)
+  def parseSList: SList = SList(parseMany(() => parseSExpr).toList)
 
   /**
     *

--- a/src/main/scala/smtlib/parser/ParserTerms.scala
+++ b/src/main/scala/smtlib/parser/ParserTerms.scala
@@ -37,19 +37,19 @@ trait ParserTerms { this: ParserCommon =>
   protected def parseTermWithoutParens(startPos: Position): Term = getPeekToken.kind match {
     case Tokens.Let =>
       eat(Tokens.Let)
-      val (head, bindings) = parseOneOrMore(parseVarBinding _)
+      val (head, bindings) = parseOneOrMore(() => parseVarBinding)
       val term = parseTerm
       Let(head, bindings, term)
 
     case Tokens.Forall =>
       eat(Tokens.Forall)
-      val (head, vars) = parseOneOrMore(parseSortedVar _)
+      val (head, vars) = parseOneOrMore(() => parseSortedVar)
       val term = parseTerm
       Forall(head, vars, term)
 
     case Tokens.Exists =>
       eat(Tokens.Exists)
-      val (head, vars) = parseOneOrMore(parseSortedVar _)
+      val (head, vars) = parseOneOrMore(() => parseSortedVar)
       val term = parseTerm
       Exists(head, vars, term)
 
@@ -57,7 +57,7 @@ trait ParserTerms { this: ParserCommon =>
       eat(Tokens.ExclamationMark)
       val term = parseTerm
       val head = parseAttribute
-      val attrs = parseUntil(Tokens.CParen, eatEnd = false)(parseAttribute _)
+      val attrs = parseUntil(Tokens.CParen, eatEnd = false)(() => parseAttribute)
       AnnotatedTerm(term, head, attrs)
 
     case Tokens.As =>
@@ -69,7 +69,7 @@ trait ParserTerms { this: ParserCommon =>
     case _ => //should be function application
       val id = parseQualifiedIdentifier 
       val head = parseTerm
-      val terms = parseUntil(Tokens.CParen, eatEnd = false)(parseTerm _)
+      val terms = parseUntil(Tokens.CParen, eatEnd = false)(() => parseTerm)
       FunctionApplication(id, head::terms.toList)
   }
 


### PR DESCRIPTION
Scala 2.13.4 refuses to convert methods without a parameter list and by-name params to functions as `m _` and requires using `() => m` instead.

This is a part of cleanups I did to get the library work with Scala 2.13 in the Renaissance benchmark suite.