### PR TITLE
Replace use of (deprecated) FunSuite with funsuite.AnyFunSuite

### DIFF
--- a/src/it/scala/smtlib/it/ProcessInterpreterTests.scala
+++ b/src/it/scala/smtlib/it/ProcessInterpreterTests.scala
@@ -3,7 +3,7 @@ package it
 
 import scala.sys.process._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.File
 import java.io.FileReader
@@ -14,7 +14,7 @@ import printer.RecursivePrinter
 import interpreters._
 
 
-class ProcessInterpreterTests extends FunSuite with TestHelpers {
+class ProcessInterpreterTests extends AnyFunSuite with TestHelpers {
 
   //TODO: properly get all interpreters
   def interpreters: Seq[Interpreter] = Seq(getZ3Interpreter)

--- a/src/it/scala/smtlib/it/SmtLibRunnerTests.scala
+++ b/src/it/scala/smtlib/it/SmtLibRunnerTests.scala
@@ -3,7 +3,7 @@ package it
 
 import scala.sys.process._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.File
 import java.io.FileReader
@@ -21,7 +21,7 @@ import interpreters._
   *
   * TODO: proper way to display warning when not all tests are run because of not found executables.
   */
-class SmtLibRunnerTests extends FunSuite with TestHelpers {
+class SmtLibRunnerTests extends AnyFunSuite with TestHelpers {
 
   filesInResourceDir("regression/smtlib/solving/all", _.endsWith(".smt2")).foreach(file => {
     if(isZ3Available) {

--- a/src/it/scala/smtlib/it/TheoriesBuilderTests.scala
+++ b/src/it/scala/smtlib/it/TheoriesBuilderTests.scala
@@ -3,7 +3,7 @@ package it
 
 import scala.sys.process._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.File
 import java.io.FileReader
@@ -16,7 +16,7 @@ import trees.CommandsResponses._
 
 
 /** Checks that formula build with theories module are correctly handled by solvers */
-class TheoriesBuilderTests extends FunSuite with TestHelpers {
+class TheoriesBuilderTests extends AnyFunSuite with TestHelpers {
 
 
   def mkTest(formula: Term, expectedStatus: Status, prefix: String) = {

--- a/src/test/scala/smtlib/common/BinaryTests.scala
+++ b/src/test/scala/smtlib/common/BinaryTests.scala
@@ -1,9 +1,9 @@
 package smtlib
 package common
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class BinaryTests extends FunSuite {
+class BinaryTests extends AnyFunSuite {
 
   test("toIntBits works with one bit") {
     assert(Binary(List(true)).toIntBits === 1)

--- a/src/test/scala/smtlib/common/HexadecimalTests.scala
+++ b/src/test/scala/smtlib/common/HexadecimalTests.scala
@@ -1,9 +1,9 @@
 package smtlib
 package common
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class HexadecimalTests extends FunSuite {
+class HexadecimalTests extends AnyFunSuite {
 
   test("Build hexadecimal with one digit string") {
     val zero = Hexadecimal.fromString("0")

--- a/src/test/scala/smtlib/common/LinkedListTests.scala
+++ b/src/test/scala/smtlib/common/LinkedListTests.scala
@@ -1,8 +1,8 @@
 package smtlib.common
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class LinkedListTests extends FunSuite {
+class LinkedListTests extends AnyFunSuite {
 
 
   test("append one element on empty list pop the same element") {

--- a/src/test/scala/smtlib/lexer/LexerTests.scala
+++ b/src/test/scala/smtlib/lexer/LexerTests.scala
@@ -8,12 +8,12 @@ import Lexer.IllegalTokenException
 
 import java.io.StringReader
 
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.TimeLimits
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.time.SpanSugar._
 
 
-class LexerTests extends FunSuite with TimeLimits {
+class LexerTests extends AnyFunSuite with TimeLimits {
 
 
   override def suiteName = "Lexer Test Suite"

--- a/src/test/scala/smtlib/parser/CommandsParserTests.scala
+++ b/src/test/scala/smtlib/parser/CommandsParserTests.scala
@@ -11,12 +11,12 @@ import trees.TreesOps
 
 import java.io.StringReader
 
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.TimeLimits
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.language.implicitConversions
 
-class CommandsParserTests extends FunSuite with TimeLimits {
+class CommandsParserTests extends AnyFunSuite with TimeLimits {
 
   override def suiteName = "SMT-LIB commands Parser suite"
 

--- a/src/test/scala/smtlib/parser/CommandsResponsesParserTests.scala
+++ b/src/test/scala/smtlib/parser/CommandsResponsesParserTests.scala
@@ -7,11 +7,11 @@ import trees.Commands._
 import trees.CommandsResponses._
 import trees.Terms._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.language.implicitConversions
 
-class CommandsResponsesParserTests extends FunSuite {
+class CommandsResponsesParserTests extends AnyFunSuite {
 
   private implicit def strToSym(str: String): SSymbol = SSymbol(str)
   private implicit def strToId(str: String): Identifier = Identifier(SSymbol(str))

--- a/src/test/scala/smtlib/parser/ParserTests.scala
+++ b/src/test/scala/smtlib/parser/ParserTests.scala
@@ -11,13 +11,13 @@ import trees.TreesOps
 
 import java.io.StringReader
 
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.TimeLimits
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.time.SpanSugar._
 
 import scala.language.implicitConversions
 
-class ParserTests extends FunSuite with TimeLimits {
+class ParserTests extends AnyFunSuite with TimeLimits {
 
   override def suiteName = "SMT-LIB Parser suite"
 

--- a/src/test/scala/smtlib/parser/TermsOpsTests.scala
+++ b/src/test/scala/smtlib/parser/TermsOpsTests.scala
@@ -1,12 +1,12 @@
 package smtlib
 package trees
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import Terms._
 import TermsOps._
 
-class TermsOpsTests extends FunSuite {
+class TermsOpsTests extends AnyFunSuite {
 
   val s1 = Sort(Identifier(SSymbol("S1")))
   val s2 = Sort(Identifier(SSymbol("S2")))

--- a/src/test/scala/smtlib/parser/TreesOpsTests.scala
+++ b/src/test/scala/smtlib/parser/TreesOpsTests.scala
@@ -1,13 +1,13 @@
 package smtlib
 package trees
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import Terms._
 import Commands._
 import TreesOps._
 
-class TreesOpsTests extends FunSuite {
+class TreesOpsTests extends AnyFunSuite {
 
   val s1 = Sort(Identifier(SSymbol("S1")))
   val s2 = Sort(Identifier(SSymbol("S2")))

--- a/src/test/scala/smtlib/printer/PrinterTests.scala
+++ b/src/test/scala/smtlib/printer/PrinterTests.scala
@@ -8,12 +8,12 @@ import parser.Parser
 
 import common._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-import scala.language.implicitConversions
 import scala.annotation.tailrec
+import scala.language.implicitConversions
 
-class PrinterTests extends FunSuite {
+class PrinterTests extends AnyFunSuite {
 
   /*
    * TODO: test the requirement from the standard:

--- a/src/test/scala/smtlib/theories/ArraysExTests.scala
+++ b/src/test/scala/smtlib/theories/ArraysExTests.scala
@@ -5,9 +5,9 @@ import trees.Terms._
 import ArraysEx._
 import Ints.{IntSort, NumeralLit}
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ArraysExTests extends FunSuite {
+class ArraysExTests extends AnyFunSuite {
 
   override def suiteName = "ArraysEx Theory test suite"
 

--- a/src/test/scala/smtlib/theories/CoreTests.scala
+++ b/src/test/scala/smtlib/theories/CoreTests.scala
@@ -4,9 +4,9 @@ package theories
 import trees.Terms._
 import Core._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class CoreTests extends FunSuite {
+class CoreTests extends AnyFunSuite {
 
   override def suiteName = "Core Theory test suite"
 

--- a/src/test/scala/smtlib/theories/FixedSizeBitVectorsTests.scala
+++ b/src/test/scala/smtlib/theories/FixedSizeBitVectorsTests.scala
@@ -4,9 +4,9 @@ package theories
 import FixedSizeBitVectors._
 import parser.Parser
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class FixedSizeBitVectorsTests extends FunSuite {
+class FixedSizeBitVectorsTests extends AnyFunSuite {
 
   override def suiteName = "Bit Vector theory test suite"
 

--- a/src/test/scala/smtlib/theories/IntsTests.scala
+++ b/src/test/scala/smtlib/theories/IntsTests.scala
@@ -3,9 +3,9 @@ package theories
 
 import Ints._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class IntsTests extends FunSuite {
+class IntsTests extends AnyFunSuite {
 
   override def suiteName = "Ints theory test suite"
 

--- a/src/test/scala/smtlib/theories/RealsTests.scala
+++ b/src/test/scala/smtlib/theories/RealsTests.scala
@@ -3,9 +3,9 @@ package theories
 
 import Reals._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class RealsTests extends FunSuite {
+class RealsTests extends AnyFunSuite {
 
   override def suiteName = "Reals theory test suite"
 

--- a/src/test/scala/smtlib/theories/experimental/SetsTests.scala
+++ b/src/test/scala/smtlib/theories/experimental/SetsTests.scala
@@ -7,9 +7,10 @@ import trees.Terms._
 import Sets._
 import Ints.{IntSort, NumeralLit}
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class SetsTests extends FunSuite with Matchers {
+class SetsTests extends AnyFunSuite with Matchers {
 
   override def suiteName = "Set theory test suite"
 

--- a/src/test/scala/smtlib/theories/experimental/StringsTests.scala
+++ b/src/test/scala/smtlib/theories/experimental/StringsTests.scala
@@ -7,9 +7,10 @@ import trees.Terms._
 import Strings._
 import Ints.NumeralLit
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class StringsTests extends FunSuite with Matchers {
+class StringsTests extends AnyFunSuite with Matchers {
 
   override def suiteName = "Strings theory test suite"
 


### PR DESCRIPTION
This is a part of cleanups I did to get the library work with Scala 2.13 in the Renaissance benchmark suite.